### PR TITLE
Pr/5

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -247,7 +247,7 @@ var Test = React.createClass({
 });
 
 var renderTest = function() {
-    React.render(<Test items={[]}/>, document.getElementById("sjh-test-react"));
+    React.render(<Test/>, document.getElementById("sjh-test-react"));
 }
 
 SP.SOD.executeFunc("sp.js");

--- a/readme.md
+++ b/readme.md
@@ -247,7 +247,7 @@ var Test = React.createClass({
 });
 
 var renderTest = function() {
-    React.render(<Test items={items}/>, document.getElementById("sjh-test-react"));
+    React.render(<Test items={[]}/>, document.getElementById("sjh-test-react"));
 }
 
 SP.SOD.executeFunc("sp.js");


### PR DESCRIPTION
Ref #5 

Thanks @wintlu for the fix. The `items` prop actually isn't used at all in the example, so I've removed it entirely from the `React.render` call. Thanks for the catch!
